### PR TITLE
[noeyso] ud-todo

### DIFF
--- a/src/api/todo/index.ts
+++ b/src/api/todo/index.ts
@@ -26,3 +26,10 @@ export const updateTodo = async (todo: ITodo) => {
     data: { todo: todo.todo, isCompleted: todo.isCompleted },
   });
 };
+
+export const deleteTodo = async (id: number) => {
+  return await apiClient({
+    method: 'delete',
+    url: `/todos/${id}`,
+  });
+};

--- a/src/api/todo/index.ts
+++ b/src/api/todo/index.ts
@@ -1,5 +1,6 @@
 import apiClient from '@/api/apiClient';
 import { createTodoType } from '@/api/todo/types';
+import { ITodo } from '@/pages/TodoPage/types';
 
 export const getTodo = async () => {
   return await apiClient({
@@ -15,5 +16,13 @@ export const createTodo = async (todo: createTodoType) => {
     data: {
       todo,
     },
+  });
+};
+
+export const updateTodo = async (todo: ITodo) => {
+  return await apiClient({
+    method: 'put',
+    url: `/todos/${todo.id}`,
+    data: { todo: todo.todo, isCompleted: todo.isCompleted },
   });
 };

--- a/src/components/todo/TodoButton.tsx
+++ b/src/components/todo/TodoButton.tsx
@@ -1,0 +1,12 @@
+import { ITodoButton } from '@/pages/TodoPage/types';
+import React from 'react';
+
+const TodoButton = ({ title, dataTestId, onClick }: ITodoButton) => {
+  return (
+    <button data-testid={dataTestId} onClick={onClick}>
+      {title}
+    </button>
+  );
+};
+
+export default TodoButton;

--- a/src/components/todo/TodoItem.tsx
+++ b/src/components/todo/TodoItem.tsx
@@ -2,12 +2,10 @@ import React from 'react';
 import { updateTodo } from '@/api/todo';
 import { ITodo, ITodoItem, TodoButtonMode } from '@/pages/TodoPage/types';
 import TodoButton from './TodoButton';
-import useInputs from '@/lib/hooks/useInputs';
 
 const TodoItem = ({ todo, getTodos }: ITodoItem) => {
-  const [modifyData, onChangeModifyData] = useInputs({
-    todo: todo.todo,
-  });
+  const [inputText, setInputText] = React.useState<string>('');
+
   const [isModify, setIsModify] = React.useState<boolean>(false);
 
   const update = (item: ITodo, exitModifyMode?: boolean) => {
@@ -38,14 +36,21 @@ const TodoItem = ({ todo, getTodos }: ITodoItem) => {
       {
         title: '제출',
         dataTestId: 'submit-button',
-        onClick: () => update({ ...todo, todo: modifyData.todo }, true),
+        onClick: () => update({ ...todo, todo: inputText }, true),
       },
       {
         title: '취소',
         dataTestId: 'cancel-button',
-        onClick: () => setIsModify(false),
+        onClick: () => {
+          setInputText(todo.todo);
+          setIsModify(false);
+        },
       },
     ],
+  };
+
+  const onChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputText(e.currentTarget.value);
   };
 
   return (
@@ -62,8 +67,8 @@ const TodoItem = ({ todo, getTodos }: ITodoItem) => {
           <input
             type="text"
             name="todo"
-            value={modifyData.todo}
-            onChange={onChangeModifyData}
+            value={inputText}
+            onChange={onChangeInput}
             data-testid="modify-input"
           />
         )}

--- a/src/components/todo/TodoItem.tsx
+++ b/src/components/todo/TodoItem.tsx
@@ -1,16 +1,24 @@
-import { ITodo } from '@/pages/TodoPage/types';
-import React, { useState } from 'react';
+import React from 'react';
+import { updateTodo } from '@/api/todo';
+import { TodoItemProps } from '@/pages/TodoPage/types';
 
-const TodoItem = ({ todo }: { todo: ITodo }) => {
-  const [isComplete, setIsComplete] = useState(todo.isCompleted);
+const TodoItem = ({ todo, getTodos }: TodoItemProps) => {
+  const onChangeCheckBox = () => {
+    updateTodo({
+      ...todo,
+      isCompleted: !todo.isCompleted,
+    }).then(() => {
+      getTodos();
+    });
+  };
 
   return (
     <li>
       <label>
         <input
           type="checkbox"
-          checked={isComplete}
-          onChange={() => setIsComplete((curr) => !curr)}
+          checked={todo.isCompleted}
+          onChange={onChangeCheckBox}
         />
         <span>{todo.todo}</span>
       </label>

--- a/src/components/todo/TodoItem.tsx
+++ b/src/components/todo/TodoItem.tsx
@@ -1,18 +1,28 @@
 import React from 'react';
-import { updateTodo } from '@/api/todo';
+import { deleteTodo, updateTodo } from '@/api/todo';
 import { ITodo, ITodoItem, TodoButtonMode } from '@/pages/TodoPage/types';
 import TodoButton from './TodoButton';
 
 const TodoItem = ({ todo, getTodos }: ITodoItem) => {
-  const [inputText, setInputText] = React.useState<string>('');
+  const [inputText, setInputText] = React.useState<string>(todo.todo);
 
   const [isModify, setIsModify] = React.useState<boolean>(false);
 
-  const update = (item: ITodo, exitModifyMode?: boolean) => {
+  const updateTodoItem = (item: ITodo, exitModifyMode?: boolean) => {
     updateTodo(item)
       .then(() => {
         getTodos();
         if (exitModifyMode) setIsModify(false);
+      })
+      .catch((err) => {
+        alert(err.response.data.log || err.log);
+      });
+  };
+
+  const deleteTodoItem = (id: number) => {
+    deleteTodo(id)
+      .then(() => {
+        getTodos();
       })
       .catch((err) => {
         alert(err.response.data.log || err.log);
@@ -29,14 +39,14 @@ const TodoItem = ({ todo, getTodos }: ITodoItem) => {
       {
         title: '삭제',
         dataTestId: 'delete-button',
-        onClick: () => alert('삭제'),
+        onClick: () => deleteTodoItem(todo.id),
       },
     ],
     modify: [
       {
         title: '제출',
         dataTestId: 'submit-button',
-        onClick: () => update({ ...todo, todo: inputText }, true),
+        onClick: () => updateTodoItem({ ...todo, todo: inputText }, true),
       },
       {
         title: '취소',
@@ -59,7 +69,9 @@ const TodoItem = ({ todo, getTodos }: ITodoItem) => {
         <input
           type="checkbox"
           checked={todo.isCompleted}
-          onChange={() => update({ ...todo, isCompleted: !todo.isCompleted })}
+          onChange={() =>
+            updateTodoItem({ ...todo, isCompleted: !todo.isCompleted })
+          }
         />
         {!isModify ? (
           <span>{todo.todo}</span>

--- a/src/components/todo/TodoItem.tsx
+++ b/src/components/todo/TodoItem.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { updateTodo } from '@/api/todo';
-import { TodoItemProps } from '@/pages/TodoPage/types';
+import { ITodoItem } from '@/pages/TodoPage/types';
+import TodoButton from './TodoButton';
 
-const TodoItem = ({ todo, getTodos }: TodoItemProps) => {
+const TodoItem = ({ todo, getTodos }: ITodoItem) => {
   const onChangeCheckBox = () => {
     updateTodo({
       ...todo,
@@ -21,6 +22,18 @@ const TodoItem = ({ todo, getTodos }: TodoItemProps) => {
           onChange={onChangeCheckBox}
         />
         <span>{todo.todo}</span>
+        <div>
+          <TodoButton
+            title="수정"
+            dataTestId="modify-button"
+            onClick={() => alert('수정')}
+          />
+          <TodoButton
+            title="삭제"
+            dataTestId="delte-button"
+            onClick={() => alert('삭제')}
+          />
+        </div>
       </label>
     </li>
   );

--- a/src/components/todo/TodoItem.tsx
+++ b/src/components/todo/TodoItem.tsx
@@ -1,16 +1,51 @@
 import React from 'react';
 import { updateTodo } from '@/api/todo';
-import { ITodoItem } from '@/pages/TodoPage/types';
+import { ITodo, ITodoItem, TodoButtonMode } from '@/pages/TodoPage/types';
 import TodoButton from './TodoButton';
+import useInputs from '@/lib/hooks/useInputs';
 
 const TodoItem = ({ todo, getTodos }: ITodoItem) => {
-  const onChangeCheckBox = () => {
-    updateTodo({
-      ...todo,
-      isCompleted: !todo.isCompleted,
-    }).then(() => {
-      getTodos();
-    });
+  const [modifyData, onChangeModifyData] = useInputs({
+    todo: todo.todo,
+  });
+  const [isModify, setIsModify] = React.useState<boolean>(false);
+
+  const update = (item: ITodo, exitModifyMode?: boolean) => {
+    updateTodo(item)
+      .then(() => {
+        getTodos();
+        if (exitModifyMode) setIsModify(false);
+      })
+      .catch((err) => {
+        alert(err.response.data.log || err.log);
+      });
+  };
+
+  const buttonMode: TodoButtonMode = {
+    default: [
+      {
+        title: '수정',
+        dataTestId: 'modify-button',
+        onClick: () => setIsModify(true),
+      },
+      {
+        title: '삭제',
+        dataTestId: 'delete-button',
+        onClick: () => alert('삭제'),
+      },
+    ],
+    modify: [
+      {
+        title: '제출',
+        dataTestId: 'submit-button',
+        onClick: () => update({ ...todo, todo: modifyData.todo }, true),
+      },
+      {
+        title: '취소',
+        dataTestId: 'cancel-button',
+        onClick: () => setIsModify(false),
+      },
+    ],
   };
 
   return (
@@ -19,19 +54,25 @@ const TodoItem = ({ todo, getTodos }: ITodoItem) => {
         <input
           type="checkbox"
           checked={todo.isCompleted}
-          onChange={onChangeCheckBox}
+          onChange={() => update({ ...todo, isCompleted: !todo.isCompleted })}
         />
-        <span>{todo.todo}</span>
+        {!isModify ? (
+          <span>{todo.todo}</span>
+        ) : (
+          <input
+            type="text"
+            name="todo"
+            value={modifyData.todo}
+            onChange={onChangeModifyData}
+            data-testid="modify-input"
+          />
+        )}
         <div>
           <TodoButton
-            title="수정"
-            dataTestId="modify-button"
-            onClick={() => alert('수정')}
+            {...(!isModify ? buttonMode.default[0] : buttonMode.modify[0])}
           />
           <TodoButton
-            title="삭제"
-            dataTestId="delte-button"
-            onClick={() => alert('삭제')}
+            {...(!isModify ? buttonMode.default[1] : buttonMode.modify[1])}
           />
         </div>
       </label>

--- a/src/pages/SignInPage.tsx
+++ b/src/pages/SignInPage.tsx
@@ -1,0 +1,76 @@
+import { postSignIn } from '@/api/auth';
+import useInputs from '@/lib/hooks/useInputs';
+import useValidation from '@/lib/hooks/useValidation';
+import { useNavigate } from 'react-router-dom';
+import token from '@/lib/token';
+import { ACCESS_TOKEN_KEY } from '@/constants/token.contant';
+import { useContext, useState } from 'react';
+import { UserContext } from '@/contexts/UserContextProvider';
+
+const SignInpage = () => {
+  const navigate = useNavigate();
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [signInData, onChangeSignInData] = useInputs({
+    email: '',
+    password: '',
+  });
+  const { setIsLogin } = useContext(UserContext);
+  const [emailStatus, passwordStatus] = useValidation(signInData);
+
+  const onSignIn = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!isProcessing) {
+      setIsProcessing(true);
+
+      postSignIn(signInData)
+        .then((res) => {
+          token.setToken(ACCESS_TOKEN_KEY, res.data.access_token);
+          setIsLogin(!!token.getToken(ACCESS_TOKEN_KEY));
+          setIsProcessing(false);
+          navigate('/todo');
+        })
+        .catch((err) => {
+          alert(err.response.data.log || err.log);
+          setIsProcessing(false);
+        });
+    }
+  };
+
+  return (
+    <div>
+      <h1>SignIn</h1>
+      <form onSubmit={onSignIn}>
+        <input
+          type="text"
+          placeholder="이메일을 입력해주세요"
+          name="email"
+          value={signInData.email}
+          onChange={onChangeSignInData}
+          data-testid="email-input"
+        />
+        {emailStatus && <div>{emailStatus}</div>}
+
+        <input
+          type="password"
+          placeholder="패스워드를 입력해주세요"
+          autoComplete="off"
+          name="password"
+          value={signInData.password}
+          onChange={onChangeSignInData}
+          data-testid="password-input"
+        />
+        {passwordStatus && <div>{passwordStatus}</div>}
+
+        <button
+          type="submit"
+          data-testid="signin-button"
+          disabled={!!(emailStatus || passwordStatus) || isProcessing}
+        >
+          로그인
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default SignInpage;

--- a/src/pages/TodoPage/index.tsx
+++ b/src/pages/TodoPage/index.tsx
@@ -23,12 +23,13 @@ const TodoPage = () => {
   useEffect(() => {
     getTodos();
   }, []);
+
   return (
     <div>
       <TodoForm submitFn={onSubmit} />
       <ul>
         {todos.map((todo) => {
-          return <TodoItem key={todo.id} todo={todo} />;
+          return <TodoItem key={todo.id} todo={todo} getTodos={getTodos} />;
         })}
       </ul>
     </div>

--- a/src/pages/TodoPage/types.ts
+++ b/src/pages/TodoPage/types.ts
@@ -11,7 +11,13 @@ export interface ITodoForm {
   submitFn: (todo: createTodoType) => void;
 }
 
-export type TodoItemProps = {
+export interface ITodoItem {
   todo: ITodo;
   getTodos: () => void;
-};
+}
+
+export interface ITodoButton {
+  title: string;
+  dataTestId: `${string}-button`;
+  onClick: () => void;
+}

--- a/src/pages/TodoPage/types.ts
+++ b/src/pages/TodoPage/types.ts
@@ -10,3 +10,8 @@ export interface ITodo {
 export interface ITodoForm {
   submitFn: (todo: createTodoType) => void;
 }
+
+export type TodoItemProps = {
+  todo: ITodo;
+  getTodos: () => void;
+};

--- a/src/pages/TodoPage/types.ts
+++ b/src/pages/TodoPage/types.ts
@@ -21,3 +21,8 @@ export interface ITodoButton {
   dataTestId: `${string}-button`;
   onClick: () => void;
 }
+
+export interface TodoButtonMode {
+  default: ITodoButton[];
+  modify: ITodoButton[];
+}


### PR DESCRIPTION
## 구현 내용
- [x] TODO의 체크박스를 통해 완료 여부를 수정
- [x] TODO 우측에 수정버튼과 삭제 버튼
- [x] 각 버튼마다 data-testid 설정
- [x] 투두리스트의 수정 기능 구현
- [x] 수정 버튼 클릭 시 수정 모드 활성화
- [x] 수정모드에서는 TODO의 내용이 input창 안에 입력된 형태
- [x]  수정 input의 data-testid 설정
- [x] 수정모드에서는 TODO 우측에 제출버튼과 취소버튼 표시
- [x] 제출버튼을 누르면 수정한 내용을 제출해서 내용 업데이트
- [x]  취소버튼을 누르면 수정내용 초기화 후 수정모드 비활성화
- [x] 투두리스트의 삭제 기능 구현
- [x] 삭제버튼 클릭 시 해당 아이템 삭제

## 참고 사항
- TodoButton 컴포넌트를 추가했습니다.
- 버튼 모드 객체를 정의하여 수정 모드 활성화 상태에 따라 버튼 정보를 받아서 TodoButton 컴포넌트에 넘겨줄 수 있도록 했습니다.