### PR TITLE
[jiheon788] ud-todo

### DIFF
--- a/src/api/todo/index.ts
+++ b/src/api/todo/index.ts
@@ -1,5 +1,5 @@
 import apiClient from '@/api/apiClient';
-import { createTodoType } from '@/api/todo/types';
+import { createTodoType, deleteTodoType, updateTodoType } from './types';
 
 export const getTodo = async () => {
   return await apiClient({
@@ -8,12 +8,30 @@ export const getTodo = async () => {
   });
 };
 
-export const createTodo = async (todo: createTodoType) => {
+export const createTodo = async ({ todo }: createTodoType) => {
   return await apiClient({
     method: 'post',
     url: '/todos',
     data: {
       todo,
     },
+  });
+};
+
+export const updateTodo = async ({ todo, isCompleted, id }: updateTodoType) => {
+  return await apiClient({
+    method: 'put',
+    url: `/todos/${id}`,
+    data: {
+      todo,
+      isCompleted,
+    },
+  });
+};
+
+export const deleteTodo = async ({ id }: deleteTodoType) => {
+  return await apiClient({
+    method: 'delete',
+    url: `/todos/${id}`,
   });
 };

--- a/src/api/todo/types.ts
+++ b/src/api/todo/types.ts
@@ -1,3 +1,13 @@
 export interface createTodoType {
   todo: string;
 }
+
+export interface updateTodoType {
+  todo: string;
+  isCompleted: boolean;
+  id: number;
+}
+
+export interface deleteTodoType {
+  id: number;
+}

--- a/src/components/todo/TodoEditor.tsx
+++ b/src/components/todo/TodoEditor.tsx
@@ -1,43 +1,48 @@
 import { updateTodo } from '@/api/todo';
 import useInputs from '@/lib/hooks/useInputs';
 import { ITodo } from '@/pages/TodoPage/types';
+import { useState } from 'react';
 
 const TodoEditor = ({
   todo,
   getTodos,
   setIsUpdate,
-  onCheckTodo,
 }: {
   todo: ITodo;
   getTodos: () => void;
   setIsUpdate: (isUpdate: boolean) => void;
-  onCheckTodo: (selectedTodo: ITodo) => void;
 }) => {
   const [todoEdit, onChangeTodoEdit] = useInputs(todo);
+  const [isProcessing, setIsProcessing] = useState(false);
 
   const onUpdate = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    setIsUpdate(false);
+    setIsProcessing(true);
 
     const { todo, isCompleted, id } = todoEdit;
-    updateTodo({ todo, isCompleted, id }).then((_) => {
-      getTodos();
-    });
+    updateTodo({ todo, isCompleted, id })
+      .then((_) => {
+        getTodos();
+      })
+      .catch((err) => {
+        alert(err.response.data.log || err.log);
+      })
+      .finally(() => {
+        setIsProcessing(false);
+        setIsUpdate(false);
+      });
   };
 
   return (
     <form onSubmit={onUpdate}>
       <label>
-        <input
-          type="checkbox"
-          checked={todo.isCompleted}
-          onChange={() => onCheckTodo(todo)}
-        />
+        <input type="checkbox" checked={todo.isCompleted} readOnly />
         <input
           data-testid="modify-input"
           name="todo"
           value={todoEdit.todo}
           onChange={onChangeTodoEdit}
+          disabled={isProcessing}
         />
       </label>
       <div role="group">

--- a/src/components/todo/TodoEditor.tsx
+++ b/src/components/todo/TodoEditor.tsx
@@ -1,0 +1,59 @@
+import { updateTodo } from '@/api/todo';
+import useInputs from '@/lib/hooks/useInputs';
+import { ITodo } from '@/pages/TodoPage/types';
+
+const TodoEditor = ({
+  todo,
+  getTodos,
+  setIsUpdate,
+  onCheckTodo,
+}: {
+  todo: ITodo;
+  getTodos: () => void;
+  setIsUpdate: (isUpdate: boolean) => void;
+  onCheckTodo: (selectedTodo: ITodo) => void;
+}) => {
+  const [todoEdit, onChangeTodoEdit] = useInputs(todo);
+
+  const onUpdate = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsUpdate(false);
+
+    const { todo, isCompleted, id } = todoEdit;
+    updateTodo({ todo, isCompleted, id }).then((_) => {
+      getTodos();
+    });
+  };
+
+  return (
+    <form onSubmit={onUpdate}>
+      <label>
+        <input
+          type="checkbox"
+          checked={todo.isCompleted}
+          onChange={() => onCheckTodo(todo)}
+        />
+        <input
+          data-testid="modify-input"
+          name="todo"
+          value={todoEdit.todo}
+          onChange={onChangeTodoEdit}
+        />
+      </label>
+      <div role="group">
+        <button type="submit" data-testid="submit-button">
+          제출
+        </button>
+        <button
+          type="button"
+          data-testid="cancel-button"
+          onClick={() => setIsUpdate(false)}
+        >
+          취소
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default TodoEditor;

--- a/src/components/todo/TodoForm.tsx
+++ b/src/components/todo/TodoForm.tsx
@@ -1,16 +1,30 @@
-import { ITodoForm } from '@/pages/TodoPage/types';
 import useInputs from '@/lib/hooks/useInputs';
-import { FormEvent } from 'react';
+import { useState } from 'react';
+import { createTodo } from '@/api/todo';
 
-const TodoForm = ({ submitFn }: ITodoForm) => {
-  const [todoData, onChangeTodoData] = useInputs({ todo: '' });
+const TodoForm = ({ getTodos }: { getTodos: () => void }) => {
+  const [todoData, onChangeTodoData, setTodoData] = useInputs({ todo: '' });
+  const [isProcessing, setIsProcessing] = useState(false);
 
-  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    submitFn(todoData.todo);
+  const onCreate = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsProcessing(true);
+
+    createTodo(todoData)
+      .then(() => {
+        getTodos();
+      })
+      .catch((err) => {
+        alert(err.response.data.log || err.log);
+      })
+      .finally(() => {
+        setIsProcessing(false);
+        setTodoData({ todo: '' });
+      });
   };
+
   return (
-    <form onSubmit={handleSubmit}>
+    <form onSubmit={onCreate}>
       <label htmlFor="todo">
         할 일 추가하기
         <input
@@ -20,6 +34,7 @@ const TodoForm = ({ submitFn }: ITodoForm) => {
           type="text"
           value={todoData.todo}
           onChange={onChangeTodoData}
+          disabled={isProcessing}
         />
       </label>
       <button type="submit" data-testid="new-todo-add-button">

--- a/src/components/todo/TodoItem.tsx
+++ b/src/components/todo/TodoItem.tsx
@@ -1,6 +1,7 @@
 import { updateTodo } from '@/api/todo';
 import { ITodo } from '@/pages/TodoPage/types';
-import React, { useState } from 'react';
+import { useState } from 'react';
+import TodoEditor from './TodoEditor';
 
 const TodoItem = ({
   todo,
@@ -23,26 +24,37 @@ const TodoItem = ({
 
   return (
     <li>
-      <label>
-        <input
-          type="checkbox"
-          checked={todo.isCompleted}
-          onChange={() => onCheckTodo(todo)}
+      {isUpdate ? (
+        <TodoEditor
+          todo={todo}
+          getTodos={getTodos}
+          setIsUpdate={setIsUpdate}
+          onCheckTodo={onCheckTodo}
         />
-        <span>{todo.todo}</span>
-      </label>
-      <div role="group">
-        <button
-          type="button"
-          data-testid="modify-button"
-          onClick={() => setIsUpdate(true)}
-        >
-          수정
-        </button>
-        <button type="button" data-testid="delete-button">
-          삭제
-        </button>
-      </div>
+      ) : (
+        <>
+          <label>
+            <input
+              type="checkbox"
+              checked={todo.isCompleted}
+              onChange={() => onCheckTodo(todo)}
+            />
+            <span>{todo.todo}</span>
+          </label>
+          <div role="group">
+            <button
+              type="button"
+              data-testid="modify-button"
+              onClick={() => setIsUpdate(true)}
+            >
+              수정
+            </button>
+            <button type="button" data-testid="delete-button">
+              삭제
+            </button>
+          </div>
+        </>
+      )}
     </li>
   );
 };

--- a/src/components/todo/TodoItem.tsx
+++ b/src/components/todo/TodoItem.tsx
@@ -11,26 +11,31 @@ const TodoItem = ({
   getTodos: () => void;
 }) => {
   const [isUpdate, setIsUpdate] = useState(false);
+  const [isProcessing, setIsProcessing] = useState(false);
 
   const onCheckTodo = (selectedTodo: ITodo) => {
+    const { todo, isCompleted, id } = selectedTodo;
+    setIsProcessing(true);
     updateTodo({
-      todo: selectedTodo.todo,
-      isCompleted: !selectedTodo.isCompleted,
-      id: selectedTodo.id,
-    }).then((_) => {
-      getTodos();
-    });
+      todo,
+      isCompleted: !isCompleted,
+      id,
+    })
+      .then((_) => {
+        getTodos();
+      })
+      .catch((err) => {
+        alert(err.response.data.log || err.log);
+      })
+      .finally(() => {
+        setIsProcessing(false);
+      });
   };
 
   return (
     <li>
       {isUpdate ? (
-        <TodoEditor
-          todo={todo}
-          getTodos={getTodos}
-          setIsUpdate={setIsUpdate}
-          onCheckTodo={onCheckTodo}
-        />
+        <TodoEditor todo={todo} getTodos={getTodos} setIsUpdate={setIsUpdate} />
       ) : (
         <>
           <label>
@@ -38,6 +43,7 @@ const TodoItem = ({
               type="checkbox"
               checked={todo.isCompleted}
               onChange={() => onCheckTodo(todo)}
+              disabled={isProcessing}
             />
             <span>{todo.todo}</span>
           </label>

--- a/src/components/todo/TodoItem.tsx
+++ b/src/components/todo/TodoItem.tsx
@@ -1,4 +1,4 @@
-import { updateTodo } from '@/api/todo';
+import { deleteTodo, updateTodo } from '@/api/todo';
 import { ITodo } from '@/pages/TodoPage/types';
 import { useState } from 'react';
 import TodoEditor from './TodoEditor';
@@ -21,6 +21,21 @@ const TodoItem = ({
       isCompleted: !isCompleted,
       id,
     })
+      .then((_) => {
+        getTodos();
+      })
+      .catch((err) => {
+        alert(err.response.data.log || err.log);
+      })
+      .finally(() => {
+        setIsProcessing(false);
+      });
+  };
+
+  const onClickDeleteButton = (id: number) => {
+    setIsProcessing(true);
+
+    deleteTodo({ id })
       .then((_) => {
         getTodos();
       })
@@ -55,7 +70,12 @@ const TodoItem = ({
             >
               수정
             </button>
-            <button type="button" data-testid="delete-button">
+            <button
+              type="button"
+              data-testid="delete-button"
+              onClick={() => onClickDeleteButton(todo.id)}
+              disabled={isProcessing}
+            >
               삭제
             </button>
           </div>

--- a/src/components/todo/TodoItem.tsx
+++ b/src/components/todo/TodoItem.tsx
@@ -33,8 +33,9 @@ const TodoItem = ({
   };
 
   const onClickDeleteButton = (id: number) => {
-    setIsProcessing(true);
+    if (!confirm('정말 삭제하시겠습니까?')) return;
 
+    setIsProcessing(true);
     deleteTodo({ id })
       .then((_) => {
         getTodos();

--- a/src/components/todo/TodoItem.tsx
+++ b/src/components/todo/TodoItem.tsx
@@ -1,19 +1,48 @@
+import { updateTodo } from '@/api/todo';
 import { ITodo } from '@/pages/TodoPage/types';
 import React, { useState } from 'react';
 
-const TodoItem = ({ todo }: { todo: ITodo }) => {
-  const [isComplete, setIsComplete] = useState(todo.isCompleted);
+const TodoItem = ({
+  todo,
+  getTodos,
+}: {
+  todo: ITodo;
+  getTodos: () => void;
+}) => {
+  const [isUpdate, setIsUpdate] = useState(false);
+
+  const onCheckTodo = (selectedTodo: ITodo) => {
+    updateTodo({
+      todo: selectedTodo.todo,
+      isCompleted: !selectedTodo.isCompleted,
+      id: selectedTodo.id,
+    }).then((_) => {
+      getTodos();
+    });
+  };
 
   return (
     <li>
       <label>
         <input
           type="checkbox"
-          checked={isComplete}
-          onChange={() => setIsComplete((curr) => !curr)}
+          checked={todo.isCompleted}
+          onChange={() => onCheckTodo(todo)}
         />
         <span>{todo.todo}</span>
       </label>
+      <div role="group">
+        <button
+          type="button"
+          data-testid="modify-button"
+          onClick={() => setIsUpdate(true)}
+        >
+          수정
+        </button>
+        <button type="button" data-testid="delete-button">
+          삭제
+        </button>
+      </div>
     </li>
   );
 };

--- a/src/pages/TodoPage/index.tsx
+++ b/src/pages/TodoPage/index.tsx
@@ -23,12 +23,13 @@ const TodoPage = () => {
   useEffect(() => {
     getTodos();
   }, []);
+
   return (
     <div>
       <TodoForm submitFn={onSubmit} />
       <ul>
         {todos.map((todo) => {
-          return <TodoItem key={todo.id} todo={todo} />;
+          return <TodoItem key={todo.id} todo={todo} getTodos={getTodos} />;
         })}
       </ul>
     </div>

--- a/src/pages/TodoPage/index.tsx
+++ b/src/pages/TodoPage/index.tsx
@@ -1,5 +1,4 @@
-import { createTodo, getTodo } from '@/api/todo';
-import { createTodoType } from '@/api/todo/types';
+import { getTodo } from '@/api/todo';
 import TodoForm from '@/components/todo/TodoForm';
 import TodoItem from '@/components/todo/TodoItem';
 import { ITodo } from '@/pages/TodoPage/types';
@@ -14,19 +13,13 @@ const TodoPage = () => {
       .catch((err) => alert(err.response.data.log || err.log));
   }, []);
 
-  const onSubmit = (todo: createTodoType) => {
-    createTodo(todo)
-      .then(() => getTodos())
-      .catch((err) => alert(err.response.data.log || err.log));
-  };
-
   useEffect(() => {
     getTodos();
   }, []);
 
   return (
     <div>
-      <TodoForm submitFn={onSubmit} />
+      <TodoForm getTodos={getTodos} />
       <ul>
         {todos.map((todo) => {
           return <TodoItem key={todo.id} todo={todo} getTodos={getTodos} />;


### PR DESCRIPTION
## 구현 내용
- [x] TODO의 체크박스를 통해 완료 여부를 수정
- [x] TODO 우측에 수정버튼과 삭제 버튼
- [x] 각 버튼마다 data-testid 설정
- [x] 투두리스트의 수정 기능 구현
- [x] 수정 버튼 클릭 시 수정 모드 활성화
- [x] 수정모드에서는 TODO의 내용이 input창 안에 입력된 형태
- [x] 수정 input의 data-testid 설정
- [x] 수정모드에서는 TODO 우측에 제출버튼과 취소버튼 표시
- [x] 제출버튼을 누르면 수정한 내용을 제출해서 내용 업데이트
- [x] 취소버튼을 누르면 수정내용 초기화 후 수정모드 비활성화
- [x] 투두리스트의 삭제 기능 구현
- [x] 삭제버튼 클릭 시 해당 아이템 삭제

## 참고 사항
- 투두 생성 함수 위치 수정
  - 기존에는 TodoItem에 있던 create 함수(`onSubmit()`)를 props로 TodoForm에 넘겼습니다. 
  - TodoForm에서 사용되는 create 함수가 부모 컴포넌트에 위치 해야 할 이유가 없다 생각해서 옮겼습니다.
  - 추가로 투두 추가시 input 비워주는 코드 추가했습니다.