### PR TITLE
[bokjunwoo] ud-todo

### DIFF
--- a/src/api/todo/index.ts
+++ b/src/api/todo/index.ts
@@ -17,3 +17,40 @@ export const createTodo = async (todo: createTodoType) => {
     },
   });
 };
+
+export const updateCheck = async (
+  todo: string,
+  id: number,
+  isCompleted: boolean,
+) => {
+  return await apiClient({
+    method: 'put',
+    url: `/todos/${id}`,
+    data: {
+      isCompleted: !isCompleted,
+      todo,
+    },
+  });
+};
+
+export const updateTodo = async (
+  todo: string,
+  id: number,
+  isCompleted: boolean,
+) => {
+  return await apiClient({
+    method: 'put',
+    url: `/todos/${id}`,
+    data: {
+      isCompleted,
+      todo,
+    },
+  });
+};
+
+export const deleteTodo = async (id: number) => {
+  return await apiClient({
+    method: 'delete',
+    url: `/todos/${id}`,
+  });
+};

--- a/src/components/todo/TodoItem.tsx
+++ b/src/components/todo/TodoItem.tsx
@@ -1,19 +1,107 @@
-import { ITodo } from '@/pages/TodoPage/types';
-import React, { useState } from 'react';
+import { deleteTodo, updateCheck, updateTodo } from '@/api/todo';
+import { ITodoItem } from '@/pages/TodoPage/types';
+import { useCallback, useState } from 'react';
 
-const TodoItem = ({ todo }: { todo: ITodo }) => {
-  const [isComplete, setIsComplete] = useState(todo.isCompleted);
+const TodoItem = ({ todo, getTodos }: ITodoItem) => {
+  const [isClick, setIsClick] = useState(false);
+
+  // 글 수정
+  const [text, setText] = useState(todo.todo);
+  const onChangeText = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setText(e.target.value);
+  }, []);
+
+  // 수정 버튼
+  const [amendButton, setAmendbutton] = useState(true);
+  const amendButtonChange = useCallback(() => {
+    setAmendbutton((prev) => !prev);
+  }, []);
+
+  // 글 수정 폼
+  const onSubmitForm = useCallback(
+    (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      if (!isClick) {
+        setIsClick(true);
+        updateTodo(text, todo.id, todo.isCompleted)
+          .then(() => {
+            getTodos();
+            setAmendbutton(true);
+            setText(text);
+            setIsClick(false);
+          })
+          .catch((err) => {
+            alert(err.response.data.log || err.log);
+            setIsClick(false);
+          });
+      }
+    },
+    [isClick, text, todo.id, todo.isCompleted, getTodos],
+  );
+
+  const removeTodo = useCallback(() => {
+    if (!isClick) {
+      setIsClick(true);
+      deleteTodo(todo.id)
+        .then(() => {
+          alert('삭제되었습니다.');
+          getTodos();
+          setIsClick(false);
+        })
+        .catch((err) => {
+          alert(err.response.data.log || err.log);
+          setIsClick(false);
+        });
+    }
+  }, [isClick, todo.id, getTodos]);
+
+  const checkboxChange = useCallback(() => {
+    updateCheck(text, todo.id, todo.isCompleted)
+      .then(() => {
+        getTodos();
+      })
+      .catch((err) => {
+        alert(err.response.data.log || err.log);
+      });
+  }, [getTodos, text, todo.id, todo.isCompleted]);
 
   return (
     <li>
       <label>
         <input
           type="checkbox"
-          checked={isComplete}
-          onChange={() => setIsComplete((curr) => !curr)}
+          checked={todo.isCompleted}
+          onChange={checkboxChange}
         />
-        <span>{todo.todo}</span>
       </label>
+
+      {amendButton ? (
+        <>
+          <span>{todo.todo}</span>
+          <button data-testid="modify-button" onClick={amendButtonChange}>
+            수정
+          </button>
+          <button data-testid="delete-button" onClick={removeTodo}>
+            삭제
+          </button>
+        </>
+      ) : (
+        <form onSubmit={onSubmitForm}>
+          <input
+            type="text"
+            value={text}
+            onChange={onChangeText}
+            data-testid="modify-input"
+            required
+          />
+          <button data-testid="submit-button" disabled={isClick}>
+            {isClick ? '제출중' : '제출'}
+          </button>
+          <button onClick={amendButtonChange} data-testid="cancel-button">
+            취소
+          </button>
+        </form>
+      )}
     </li>
   );
 };

--- a/src/pages/TodoPage/index.tsx
+++ b/src/pages/TodoPage/index.tsx
@@ -22,13 +22,14 @@ const TodoPage = () => {
 
   useEffect(() => {
     getTodos();
-  }, []);
+  }, [getTodos]);
+
   return (
     <div>
       <TodoForm submitFn={onSubmit} />
       <ul>
         {todos.map((todo) => {
-          return <TodoItem key={todo.id} todo={todo} />;
+          return <TodoItem key={todo.id} todo={todo} getTodos={getTodos} />;
         })}
       </ul>
     </div>

--- a/src/pages/TodoPage/types.ts
+++ b/src/pages/TodoPage/types.ts
@@ -10,3 +10,8 @@ export interface ITodo {
 export interface ITodoForm {
   submitFn: (todo: createTodoType) => void;
 }
+
+export interface ITodoItem {
+  todo: ITodo;
+  getTodos: () => void;
+}


### PR DESCRIPTION
## 구현 내용

- [x]  TODO의 체크박스를 통해 완료 여부를 수정
- [x]  TODO 우측에 수정버튼과 삭제 버튼
- [x]  각 버튼마다 data-testid 설정
- [x]  투두리스트의 수정 기능 구현
- [x]  수정 버튼 클릭 시 수정 모드 활성화
- [x]  수정모드에서는 TODO의 내용이 input창 안에 입력된 형태
- [x]  수정 input의 data-testid 설정
- [x]  수정모드에서는 TODO 우측에 제출버튼과 취소버튼 표시
- [x]  제출버튼을 누르면 수정한 내용을 제출해서 내용 업데이트
- [x]  취소버튼을 누르면 수정내용 초기화 후 수정모드 비활성화
- [x]  투두리스트의 삭제 기능 구현
- [x]  삭제버튼 클릭 시 해당 아이템 삭제

## 참고 사항
- getTodos를 TodoItem 컴포넌트에 전달해 useEffect를 이용해 페이지 렌더를 구현했습니다.